### PR TITLE
Allow to initialize without arguments

### DIFF
--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -10,7 +10,7 @@ class CoincheckClient
   @@base_url = "https://coincheck.jp/"
   @@ssl = true
 
-  def initialize(key, secret, params = {})
+  def initialize(key = nil, secret = nil, params = {})
     @key = key
     @secret = secret
     if !params[:base_url].nil?


### PR DESCRIPTION
The use case is when we want to call only the Public API.