### PR TITLE
add transactions_pagination api

### DIFF
--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -45,6 +45,12 @@ class CoincheckClient
     request_for_get(uri, headers)
   end
 
+  def read_transactions_pagination
+    uri = URI.parse @@base_url + "api/exchange/orders/transactions_pagination"
+    headers = get_signature(uri, @key, @secret)
+    request_for_get(uri, headers)
+  end
+
   def read_positions(body = {})
     uri = URI.parse @@base_url + "api/exchange/leverage/positions"
     headers = get_signature(uri, @key, @secret, body.to_json)


### PR DESCRIPTION
## What
Add  `transactions_pagination `method

Please excuse me for writing Japanese
https://coincheck.com/ja/documents/exchange/api#order-transactions
これだと取引履歴が全部取れない、全部取るならtransactions_paginationを使え、と言われました。
でもgem対応してないですよね。
なので作りました。
これでも全部取れない気がする。。。