### PR TITLE
Add read transactions_pagination of exchange orders

### DIFF
--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -44,6 +44,12 @@ class CoincheckClient
     headers = get_signature(uri, @key, @secret)
     request_for_get(uri, headers)
   end
+  
+  def read_transactions_pagination(body = {})
+    uri = URI.parse @@base_url + "api/exchange/orders/transactions_pagination"
+    headers = get_signature(uri, @key, @secret, body.to_json)
+    request_for_get(uri, headers, body)
+  end
 
   def read_positions(body = {})
     uri = URI.parse @@base_url + "api/exchange/leverage/positions"


### PR DESCRIPTION
Add method to GET /api/exchange/orders/transactions_pagination.
https://coincheck.com/ja/documents/exchange/api#order-transactions-pagination

The parameter `body` is for pagination parameters.
https://coincheck.com/ja/documents/exchange/api#pagination

ex. `read_transactions_pagination(limit: 20, starting_after: 12345)`
