### PR TITLE
Intruding circleci build & update read_position method parameter 

### DIFF
--- a/.circle.yml
+++ b/.circle.yml
@@ -1,15 +1,36 @@
 version: 2
+jobs:
+  build:
+    docker:
+       - image: circleci/ruby:2.4.1-node-browsers
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
-machine:
-  timezone:
-    Asia/Tokyo
-  ruby:
-    version:
-      2.2.2
-dependencies:
-  override:
-    - bundle install:
-        timeout: 180
-test:
-  override:
-    - bundle exec rspec
+            bundle exec rspec --format progress \
+                            --format RspecJunitFormatter \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress \
+                            "${TEST_FILES}"
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circle.yml
+++ b/.circle.yml
@@ -1,0 +1,15 @@
+version: 2
+
+machine:
+  timezone:
+    Asia/Tokyo
+  ruby:
+    version:
+      2.2.2
+dependencies:
+  override:
+    - bundle install:
+        timeout: 180
+test:
+  override:
+    - bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 group :development, :test do
   gem 'dotenv'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,49 @@
+PATH
+  remote: .
+  specs:
+    ruby_coincheck_client (0.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    dotenv (2.2.1)
+    hashdiff (0.3.7)
+    public_suffix (3.0.1)
+    rake (10.4.2)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    safe_yaml (1.0.4)
+    webmock (3.1.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.9)
+  dotenv
+  rake (~> 10.0)
+  rspec
+  ruby_coincheck_client!
+  webmock
+
+BUNDLED WITH
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/coincheckjp/ruby_coincheck_client.svg?style=svg)](https://circleci.com/gh/coincheckjp/ruby_coincheck_client)
+
 # RubyCoincheckClient
 
 This is ruby client implementation for Coincheck API.

--- a/examples/private.rb
+++ b/examples/private.rb
@@ -7,5 +7,6 @@ puts cc.read_balance.body
 puts cc.read_leverage_balance.body
 puts cc.read_accounts.body
 puts cc.read_transactions.body
+puts cc.read_positions(status: 'open').body
 puts cc.read_positions.body
 puts cc.read_orders.body

--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -45,10 +45,12 @@ class CoincheckClient
     request_for_get(uri, headers)
   end
 
-  def read_positions(params = {})
+  def read_positions(status: nil)
+    params = { status: status }
     uri = URI.parse @@base_url + "api/exchange/leverage/positions"
+    uri.query = URI.encode_www_form(params)
     headers = get_signature(uri, @key, @secret)
-    request_for_get(uri, headers, params)
+    request_for_get(uri, headers)
   end
 
   def read_orders
@@ -78,9 +80,10 @@ class CoincheckClient
   end
 
   def read_orders_rate(order_type:, pair: Pair::BTC_JPY, price: nil, amount: nil)
-    uri = URI.parse @@base_url + "api/exchange/orders/rate"
     params = { order_type: order_type, pair: pair, price: price, amount: amount }
-    request_for_get(uri, {}, params)
+    uri = URI.parse @@base_url + "api/exchange/orders/rate"
+    uri.query = URI.encode_www_form(params)
+    request_for_get(uri)
   end
 
   def create_send_money(address:, amount:)
@@ -96,15 +99,17 @@ class CoincheckClient
   def read_send_money(currency: "BTC")
     params = { currency: currency }
     uri = URI.parse @@base_url + "api/send_money"
+    uri.query = URI.encode_www_form(params)
     headers = get_signature(uri, @key, @secret)
-    request_for_get(uri, headers, params)
+    request_for_get(uri, headers)
   end
 
   def read_deposit_money(currency: "BTC")
     params = { currency: currency }
     uri = URI.parse @@base_url + "api/deposit_money"
+    uri.query = URI.encode_www_form(params)
     headers = get_signature(uri, @key, @secret)
-    request_for_get(uri, headers, params)
+    request_for_get(uri, headers)
   end
 
   def create_deposit_money_fast(id: )
@@ -226,8 +231,7 @@ class CoincheckClient
       end
     end
 
-    def request_for_get(uri, headers = {}, params = nil)
-      uri.query = URI.encode_www_form(params) if params
+    def request_for_get(uri, headers = {})
       request = Net::HTTP::Get.new(uri.request_uri, initheader = custom_header(headers))
       http_request(uri, request)
     end

--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -129,7 +129,7 @@ class CoincheckClient
   end
 
   def read_rate(pair: Pair::BTC_JPY)
-    uri = URI.parse @@base_url + "/api/rate/#{pair}"
+    uri = URI.parse @@base_url + "api/rate/#{pair}"
     request_for_get(uri)
   end
 

--- a/lib/ruby_coincheck_client/version.rb
+++ b/lib/ruby_coincheck_client/version.rb
@@ -1,3 +1,3 @@
 module RubyCoincheckClient
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/ruby_coincheck_client/coincheck_client_spec.rb
+++ b/spec/ruby_coincheck_client/coincheck_client_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe CoincheckClient do
+  describe '#read_balance' do
+    it 'return status code 200' do
+      stub_request(
+        :get, "https://coincheck.com/api/accounts/balance"
+      ).to_return(
+        body: {
+          "success": true,
+          "jpy": "0.8401",
+          "btc": "7.75052654",
+          "jpy_reserved": "3000.0",
+          "btc_reserved": "3.5002",
+          "jpy_lend_in_use": "0",
+          "btc_lend_in_use": "0.3",
+          "jpy_lent": "0",
+          "btc_lent": "1.2",
+          "jpy_debt": "0",
+          "btc_debt": "0"
+        }.to_json,
+        status: 200
+      )
+
+      cc = CoincheckClient.new('api_key', 'secret_key')
+      res = cc.read_balance
+      expect(res.code).to eq '200'
+      expect(JSON.parse(res.body)['success']).to eq true
+      expect(JSON.parse(res.body)['btc']).to eq "7.75052654"
+    end
+  end
+
+  describe '#read_positions' do
+    it 'return status code 200' do
+      stub_request(
+        :get, "https://coincheck.com/api/exchange/leverage/positions?status=open"
+      ).with(
+        :headers => { 'Content-Length' => 7 }
+      ).to_return(
+        body: {
+          "success": true,
+          "pagination":{
+            "limit": 10,
+            "order": "desc",
+            "starting_after": nil,
+            "ending_before": nil
+          },
+          "data":[
+            {
+              "id": 202835,
+              "order_type": "buy",
+              "rate": 26890,
+              "pair": "btc_jpy",
+              "pending_amount": "0.5527",
+              "pending_market_buy_amount": nil,
+              "stop_loss_rate": nil,
+              "created_at": "2015-01-10T05:55:38.000Z"
+            }
+          ]
+        }.to_json,
+        status: 200
+      )
+
+      cc = CoincheckClient.new('api_key', 'secret_key')
+      res = cc.read_positions(status: 'open')
+      expect(res.code).to eq '200'
+      expect(JSON.parse(res.body)['success']).to eq true
+      expect(JSON.parse(res.body)['data'][0]['id']).to eq 202835
+    end
+  end
+
+  describe '#get_signature' do
+  end
+end

--- a/spec/ruby_coincheck_client/coincheck_client_spec.rb
+++ b/spec/ruby_coincheck_client/coincheck_client_spec.rb
@@ -1,7 +1,98 @@
 require 'spec_helper'
 
 describe CoincheckClient do
+  describe '#read_trades' do
+    let(:cc) { CoincheckClient.new }
+    let(:res) { cc.read_trades }
+    let(:body) { JSON.parse(res.body) }
+
+    it 'return status code 200' do
+      stub_request(
+        :get, "https://coincheck.com/api/trades"
+      ).to_return(
+        body: [
+          {
+            "id": 82,
+            "amount": "0.28391",
+            "rate": 35400,
+            "order_type": "sell",
+            "created_at": "2015-01-10T05:55:38.000Z"
+          },
+          {
+            "id": 81,
+            "amount": "0.1",
+            "rate": 36120,
+            "order_type": "buy",
+            "created_at": "2015-01-09T15:25:13.000Z"
+          }
+        ].to_json,
+        status: 200
+      )
+
+      expect(res.code).to eq '200'
+      expect(body[0]['id']).to eq 82
+      expect(body[0]['amount']).to eq "0.28391"
+    end
+  end
+
+  describe '#order_books' do
+    let(:cc) { CoincheckClient.new }
+    let(:res) { cc.read_order_books }
+    let(:body) { JSON.parse(res.body) }
+
+    it 'return status code 200' do
+      stub_request(
+        :get, "https://coincheck.com/api/order_books"
+      ).to_return(
+        body: {
+          "asks": [
+            [ 27330, "2.25" ],
+            [ 27340, "0.45" ]
+          ],
+          "bids": [
+            [ 27240, "1.1543" ],
+            [ 26800, "1.2226" ]
+          ]
+        }.to_json,
+        status: 200
+      )
+
+      expect(res.code).to eq '200'
+      expect(body['asks'][0][0]).to eq 27330
+      expect(body['asks'][0][1]).to eq "2.25"
+    end
+  end
+
+  describe '#read_rate' do
+    let(:cc) { CoincheckClient.new }
+    let(:res) { cc.read_rate }
+    let(:body) { JSON.parse(res.body) }
+
+    it 'return status code 200' do
+      stub_request(
+        :get, "https://coincheck.com/api/rate/#{CoincheckClient::Pair::BTC_JPY}"
+      ).to_return(
+        body: {
+          "success": true,
+          "rate": 60000,
+          "price": 70000,
+          "amount": 1
+        }.to_json,
+        status: 200
+      )
+
+      expect(res.code).to eq '200'
+      expect(body['success']).to eq true
+      expect(body['rate']).to eq 60000
+      expect(body['price']).to eq 70000
+    end
+  end
+
   describe '#read_balance' do
+    let(:cc) { CoincheckClient.new('api_key', 'secret_key') }
+    let(:res) { cc.read_balance }
+    let(:body) { JSON.parse(res.body) }
+
     it 'return status code 200' do
       stub_request(
         :get, "https://coincheck.com/api/accounts/balance"
@@ -22,15 +113,17 @@ describe CoincheckClient do
         status: 200
       )
 
-      cc = CoincheckClient.new('api_key', 'secret_key')
-      res = cc.read_balance
       expect(res.code).to eq '200'
-      expect(JSON.parse(res.body)['success']).to eq true
-      expect(JSON.parse(res.body)['btc']).to eq "7.75052654"
+      expect(body['success']).to eq true
+      expect(body['btc']).to eq "7.75052654"
     end
   end
 
   describe '#read_positions' do
+    let(:cc) { CoincheckClient.new('api_key', 'secret_key') }
+    let(:res) { cc.read_positions(status: 'open') }
+    let(:body) { JSON.parse(res.body) }
+
     it 'return status code 200' do
       stub_request(
         :get, "https://coincheck.com/api/exchange/leverage/positions?status=open"
@@ -59,11 +152,9 @@ describe CoincheckClient do
         status: 200
       )
 
-      cc = CoincheckClient.new('api_key', 'secret_key')
-      res = cc.read_positions(status: 'open')
       expect(res.code).to eq '200'
-      expect(JSON.parse(res.body)['success']).to eq true
-      expect(JSON.parse(res.body)['data'][0]['id']).to eq 202835
+      expect(body['success']).to eq true
+      expect(body['data'][0]['id']).to eq 202835
     end
   end
 

--- a/spec/ruby_coincheck_client/coincheck_client_spec.rb
+++ b/spec/ruby_coincheck_client/coincheck_client_spec.rb
@@ -34,8 +34,6 @@ describe CoincheckClient do
     it 'return status code 200' do
       stub_request(
         :get, "https://coincheck.com/api/exchange/leverage/positions?status=open"
-      ).with(
-        :headers => { 'Content-Length' => 7 }
       ).to_return(
         body: {
           "success": true,

--- a/spec/ruby_coincheck_client_spec.rb
+++ b/spec/ruby_coincheck_client_spec.rb
@@ -4,8 +4,4 @@ describe RubyCoincheckClient do
   it 'has a version number' do
     expect(RubyCoincheckClient::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'ruby_coincheck_client'
+require_relative '../lib/ruby_coincheck_client'
+require 'webmock'
+
+include WebMock::API
+WebMock.enable!


### PR DESCRIPTION
- Add CircleCI builds
- Add some public, private endpoint specs
- Updated `read_position` method parameter, to be able to pass `status` easily