### PR TITLE
Fix spec change public trades

### DIFF
--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -123,8 +123,10 @@ class CoincheckClient
     request_for_get(uri)
   end
 
-  def read_trades
+  def read_trades(pair: Pair::BTC_JPY, limit: nil, order: nil)
+    params = { pair: pair, limit: limit, order: order }
     uri = URI.parse @@base_url + "api/trades"
+    uri.query = URI.encode_www_form(params)
     request_for_get(uri)
   end
 


### PR DESCRIPTION
[取引履歴取得APIの仕様変更について \| Coincheck（コインチェック）](https://coincheck.com/blog/4599) の通り、Public API 全取引履歴 取得のパラメータに変更があったため対応しました。

必須パラメータ `pair` 
任意パラメータ `limit`, `order`

`starting_before` と `ending_before` も指定できると書いてあったため試したのですが、`{"success"=>false, "error"=>"invalid parameter"}`となってしまいました。
そのため、指定しても問題なかった `limit` `order` のみを現時点では対応しています。

#18 とコンフリクトするのですが、こっちでコードを統一したいと思います。
(勝手にやるのも微妙なので、レビューでコメントもらえると嬉しいです)