### PR TITLE
modify read_trades and add transactions_paginations

### DIFF
--- a/examples/private.rb
+++ b/examples/private.rb
@@ -10,4 +10,4 @@ puts cc.read_transactions.body
 puts cc.read_positions(status: 'open').body
 puts cc.read_positions.body
 puts cc.read_trades().body
-puts cc.read_page_transactions().body
+puts cc.read_page_transactions.body

--- a/examples/private.rb
+++ b/examples/private.rb
@@ -9,4 +9,5 @@ puts cc.read_accounts.body
 puts cc.read_transactions.body
 puts cc.read_positions(status: 'open').body
 puts cc.read_positions.body
-puts cc.read_orders.body
+puts cc.read_trades().body
+puts cc.read_page_transactions().body

--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -45,7 +45,7 @@ class CoincheckClient
     request_for_get(uri, headers)
   end
 
-  def read_page_transactions()
+  def read_page_transactions
     uri = URI.parse @@base_url + "api/exchange/orders/transactions_pagination"
     headers = get_signature(uri, @key, @secret)
     request_for_get(uri, headers)

--- a/lib/ruby_coincheck_client/coincheck_client.rb
+++ b/lib/ruby_coincheck_client/coincheck_client.rb
@@ -45,6 +45,12 @@ class CoincheckClient
     request_for_get(uri, headers)
   end
 
+  def read_page_transactions()
+    uri = URI.parse @@base_url + "api/exchange/orders/transactions_pagination"
+    headers = get_signature(uri, @key, @secret)
+    request_for_get(uri, headers)
+  end
+
   def read_positions(status: nil)
     params = { status: status }
     uri = URI.parse @@base_url + "api/exchange/leverage/positions"
@@ -123,8 +129,10 @@ class CoincheckClient
     request_for_get(uri)
   end
 
-  def read_trades
+  def read_trades(pair: Pair::BTC_JPY )
+    params = {pair: Pair::BTC_JPY }
     uri = URI.parse @@base_url + "api/trades"
+    uri.query = URI.encode_www_form(params)
     request_for_get(uri)
   end
 

--- a/spec/ruby_coincheck_client/coincheck_client_spec.rb
+++ b/spec/ruby_coincheck_client/coincheck_client_spec.rb
@@ -8,7 +8,7 @@ describe CoincheckClient do
 
     it 'return status code 200' do
       stub_request(
-        :get, "https://coincheck.com/api/trades"
+        :get, "https://coincheck.com/api/trades/#{CoincheckClient::Pair::BTC_JPY}"
       ).to_return(
         body: [
           {

--- a/spec/ruby_coincheck_client/coincheck_client_spec.rb
+++ b/spec/ruby_coincheck_client/coincheck_client_spec.rb
@@ -8,7 +8,7 @@ describe CoincheckClient do
 
     it 'return status code 200' do
       stub_request(
-        :get, "https://coincheck.com/api/trades/#{CoincheckClient::Pair::BTC_JPY}"
+        :get, "https://coincheck.com/api/trades?pair=#{CoincheckClient::Pair::BTC_JPY}"
       ).to_return(
         body: [
           {


### PR DESCRIPTION
- [取引履歴取得APIの仕様変更](https://coincheck.com/blog/4599) のため、`通貨ペアパラメータを指定`
- `"api/exchange/orders/transactions_pagination` がなかったので追加

