### PR TITLE
Fix private api example

### DIFF
--- a/examples/private.rb
+++ b/examples/private.rb
@@ -9,5 +9,5 @@ puts cc.read_accounts.body
 puts cc.read_transactions.body
 puts cc.read_positions(status: 'open').body
 puts cc.read_positions.body
-puts cc.read_trades().body
+puts cc.read_orders.body
 puts cc.read_page_transactions.body


### PR DESCRIPTION
#21 で `read_orders` が `read_trades` に置き換わってますが、
- `read_orders` : Private API [未決済の注文一覧](https://coincheck.com/ja/documents/exchange/api#order-opens)
- `read_trades` : Public API [全取引履歴](https://coincheck.com/ja/documents/exchange/api#public-trades)
です。